### PR TITLE
Update ImageResize.php

### DIFF
--- a/src/Helpers/ImageResize.php
+++ b/src/Helpers/ImageResize.php
@@ -18,7 +18,7 @@ function imageUrl($imagePath = '', $width = null, $height = null, $config = arra
 
     // Setup the image URLs
     // - You can add ASSET_URL=http://... to your .env to reference images through a CDN
-    $hostname = env('ASSET_URL', env('APP_URL', 'http://localhost'));
+    $hostname = config('app.asset_url', env('APP_URL', 'http://localhost'));
     $urlPrefix = $hostname . '/storage/';
     $diskPath = str_replace($urlPrefix, '', $cachedUrl);
 


### PR DESCRIPTION
I have discovered an issue, if the config is cached, using $hostname = env() would return the fallback variable.
To work with cached config files is necessary to use config()